### PR TITLE
ADD Binance exchange overwriting CRO exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__
-logfile.log
+logfile*.log
 config/user_config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+__pycache__
 logfile.log
 config/user_config.yaml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ```
 pip3 install cryptocom.exchange
+pip3 install python-binance
 pip3 install yaml
 ```
 

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -1,28 +1,32 @@
 ---  # default config
 
-# API
-cryptocom_api_key: <your Crypto.com Exchange API key here>
-cryptocom_api_secret: <your Crypto.com Exchange API secret here>
-binance_api_key: <your Binance Exchange API key here>
-binance_api_secret: <your Binance Exchange API secret here>
+# EXCHANGE (Select which exchange you want to run Corecito on. Possible values -> 'crypto.com' or 'binance')
+corecito_exchange: crypto.com
 
-# CORE NUMBER
+# API
+api_key: <your Crypto.com Exchange or Binance API key here>
+api_secret: <your Crypto.com Exchange or Binance API secret here>
+
+# CORE NUMBER SETTINGS
 core_number: 2 # Ethers
 max_decimals_buy: 6 # This is the limit Crypto.com has on ETH_BTC pair https://crypto.com/exchange/trade/spot/ETH_BTC
 max_decimals_sell: 3
-trading_pair: ETH_BTC # This must be one of the pairs listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/pairs.py
-binance_trading_pair: ETHBTC # This must be one of the pairs listed in Binance
-core_number_currency: ETH # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
-base_currency: BTC # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 min_core_number_increase_percentage: 3
 max_core_number_increase_percentage: 10
 min_core_number_decrease_percentage: 3
 max_core_number_decrease_percentage: 10
 
+# EXCHANGE SETTINGS
+cryptocom_trading_pair: ETH_BTC # This must be one of the pairs listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/pairs.py
+cryptocom_core_number_currency: ETH # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
+cryptocom_base_currency: BTC # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
+binance_trading_pair: ETHBTC # This must be one of the pairs listed in Binance
+binance_core_number_currency: ETH # # This must be one of the coins listed in Binance
+binance_base_currency: BTC # # This must be one of the coins listed in Binance
+
 # CORECITO MODES
 safe_mode_on: True # True => no real trades will be made; False => real trades will be made
 test_mode_on: True # (True => Corecito will run just once ; False => Corecito will run forever until stopped)
-binance_test_mode_on: True # (True => Corecito will run just once ; False => Corecito will run forever until stopped)
 
 # LOOP SETTINGS
 seconds_between_iterations: 5

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -19,7 +19,7 @@ cryptocom_trading_pair: ETH_BTC # This must be one of the pairs listed in https:
 cryptocom_core_number_currency: ETH # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 cryptocom_base_currency: BTC # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 cryptocom_max_decimals_buy: 6 # This is the limit Crypto.com has on ETH_BTC pair https://crypto.com/exchange/trade/spot/ETH_BTC
-cryptocom_max_decimals_sell: 6
+cryptocom_max_decimals_sell: 3
 binance_trading_pair: ETHBTC # This must be one of the pairs listed in Binance
 binance_core_number_currency: ETH # # This must be one of the coins listed in Binance
 binance_base_currency: BTC # # This must be one of the coins listed in Binance

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -9,8 +9,6 @@ api_secret: <your Crypto.com Exchange or Binance API secret here>
 
 # CORE NUMBER SETTINGS
 core_number: 2 # Ethers
-max_decimals_buy: 6 # This is the limit Crypto.com has on ETH_BTC pair https://crypto.com/exchange/trade/spot/ETH_BTC
-max_decimals_sell: 3
 min_core_number_increase_percentage: 3
 max_core_number_increase_percentage: 10
 min_core_number_decrease_percentage: 3
@@ -20,9 +18,13 @@ max_core_number_decrease_percentage: 10
 cryptocom_trading_pair: ETH_BTC # This must be one of the pairs listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/pairs.py
 cryptocom_core_number_currency: ETH # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 cryptocom_base_currency: BTC # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
+cryptocom_max_decimals_buy: 6 # This is the limit Crypto.com has on ETH_BTC pair https://crypto.com/exchange/trade/spot/ETH_BTC
+cryptocom_max_decimals_sell: 6
 binance_trading_pair: ETHBTC # This must be one of the pairs listed in Binance
 binance_core_number_currency: ETH # # This must be one of the coins listed in Binance
 binance_base_currency: BTC # # This must be one of the coins listed in Binance
+binance_max_decimals_buy: 6
+binance_max_decimals_sell: 6
 
 # CORECITO MODES
 safe_mode_on: True # True => no real trades will be made; False => real trades will be made

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -2,13 +2,16 @@
 
 # API
 cryptocom_api_key: <your Crypto.com Exchange API key here>
-cryptocom_api_secret: <your Crypto.com Exchange API private key here>
+cryptocom_api_secret: <your Crypto.com Exchange API secret here>
+binance_api_key: <your Binance Exchange API key here>
+binance_api_secret: <your Binance Exchange API secret here>
 
 # CORE NUMBER
 core_number: 2 # Ethers
 max_decimals_buy: 6 # This is the limit Crypto.com has on ETH_BTC pair https://crypto.com/exchange/trade/spot/ETH_BTC
 max_decimals_sell: 3
 trading_pair: ETH_BTC # This must be one of the pairs listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/pairs.py
+binance_trading_pair: ETHBTC # This must be one of the pairs listed in Binance
 core_number_currency: ETH # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 base_currency: BTC # this must be one of the currencies listed in https://github.com/goincrypto/cryptocom-exchange/blob/master/src/cryptocom/exchange/coins.py
 min_core_number_increase_percentage: 3
@@ -19,6 +22,7 @@ max_core_number_decrease_percentage: 10
 # CORECITO MODES
 safe_mode_on: True # True => no real trades will be made; False => real trades will be made
 test_mode_on: True # (True => Corecito will run just once ; False => Corecito will run forever until stopped)
+binance_test_mode_on: True # (True => Corecito will run just once ; False => Corecito will run forever until stopped)
 
 # LOOP SETTINGS
 seconds_between_iterations: 5

--- a/corecito.py
+++ b/corecito.py
@@ -76,7 +76,7 @@ async def main():
         logger.info(f'\n\n>>> Buying: {tx_result:.6f} {account.base_currency} at {buy_price} taking {missing:.6f} {account.core_number_currency} from reserves\n')
         # Buy missing base currency; ie. => in ETH_BTC pair, buy missing BTC => Sell ETH
         if (not config['safe_mode_on']):
-          await account.order_market_sell(tx_result, missing)
+          await account.order_market_sell(missing)
           #account.order_market_sell(symbol=pair, quantity=missing)
 
       elif coreNumberPlummeted(account.core_number, deviated_core_number, account.max_core_number_decrease_percentage):

--- a/corecito.py
+++ b/corecito.py
@@ -67,7 +67,7 @@ async def main():
         logger.info(f'\n\n>>> Selling: {tx_result:.6f} {account.base_currency} at {buy_price} to park an excess of {excess:.6f} {account.core_number_currency}\n')
         # Sell excess of base currency ie. => in ETH_BTC pair, sell excess BTC => Buy ETH
         if (not config['safe_mode_on']):
-          await account.order_market_buy(quantity=excess)
+          await account.order_market_buy(tx_result, excess)
           #account.order_market_buy(symbol=pair, quantity=excess)
 
       elif coreNumberDecreased(account.core_number, deviated_core_number, account.min_core_number_decrease_percentage, account.max_core_number_decrease_percentage):
@@ -76,7 +76,7 @@ async def main():
         logger.info(f'\n\n>>> Buying: {tx_result:.6f} {account.base_currency} at {buy_price} taking {missing:.6f} {account.core_number_currency} from reserves\n')
         # Buy missing base currency; ie. => in ETH_BTC pair, buy missing BTC => Sell ETH
         if (not config['safe_mode_on']):
-          await account.order_market_sell(quantity=missing)
+          await account.order_market_sell(tx_result, missing)
           #account.order_market_sell(symbol=pair, quantity=missing)
 
       elif coreNumberPlummeted(account.core_number, deviated_core_number, account.max_core_number_decrease_percentage):

--- a/corecito.py
+++ b/corecito.py
@@ -13,13 +13,8 @@ async def main():
   config = get_config()
   logger = setupLogger('logfile-' + config['corecito_exchange'] + '.log')
 
-  #account = Client(api_key=config['binance_api_key'], api_secret=config['binance_api_secret'])
   account = CorecitoAccount(config=config)
   logger.info(f'Working on {account.exchange.capitalize()} Exchange\n')
-  #core_number = config['core_number']
-  #pair = config['binance_trading_pair']
-  #base_currency = config['base_currency']
-  #core_number_currency = config['core_number_currency']
 
   iteration = 0
 
@@ -28,8 +23,6 @@ async def main():
       iteration += 1
       print(f'------------ Iteration {iteration} ------------')
       # Get BTC/ETH ticker info
-      #tickers = account.get_orderbook_tickers()
-      # Example Binance {'symbol': 'ETHBTC', 'bidPrice': '0.02706800', 'bidQty': '7.30000000', 'askPrice': '0.02707300', 'askQty': '24.00000000'} # Bid == BUY, ask == SELL
       ticker = await account.get_tickers()
       buy_price = float(ticker["buy_price"])
       sell_price = float(ticker["sell_price"])
@@ -37,11 +30,6 @@ async def main():
 
       # Get my base and Core Number currency balances
       balances = await account.get_balances()
-      #base_currency_balance = account.get_asset_balance(asset=base_currency)
-      #base_currency_available = float(base_currency_balance["free"])
-      # EXAMPLE BTC_balance:Balance(total=0.04140678, available=3.243e-05, in_orders=0.04137435, in_stake=0, coin=Coin(name='BTC'))
-      # Get my Core Number currency balance
-      #core_number_currency_balance = account.get_asset_balance(asset=core_number_currency)
 
       logger.info(f"Balances\n(Base) {account.base_currency} balance:{balances['base_currency_balance']} \n(Core) {account.core_number_currency} balance:{balances['core_number_currency_balance']}\n")
 
@@ -68,7 +56,6 @@ async def main():
         # Sell excess of base currency ie. => in ETH_BTC pair, sell excess BTC => Buy ETH
         if (not config['safe_mode_on']):
           await account.order_market_buy(tx_result, excess)
-          #account.order_market_buy(symbol=pair, quantity=excess)
 
       elif coreNumberDecreased(account.core_number, deviated_core_number, account.min_core_number_decrease_percentage, account.max_core_number_decrease_percentage):
         logger.info(f'Decreased {decrease_percentage:.2f}% - missing {missing:.6f} {account.core_number_currency} denominated in {account.base_currency}')
@@ -77,7 +64,6 @@ async def main():
         # Buy missing base currency; ie. => in ETH_BTC pair, buy missing BTC => Sell ETH
         if (not config['safe_mode_on']):
           await account.order_market_sell(missing)
-          #account.order_market_sell(symbol=pair, quantity=missing)
 
       elif coreNumberPlummeted(account.core_number, deviated_core_number, account.max_core_number_decrease_percentage):
         logger.info(f'> Plummeted {decrease_percentage:.2f}%\nConsider updating CoreNumber to {deviated_core_number:.6f}')

--- a/corecito.py
+++ b/corecito.py
@@ -6,10 +6,6 @@ import yaml
 import sys
 import traceback
 from os.path import exists
-from binance.client import Client
-import cryptocom.exchange as cro
-from cryptocom.exchange.structs import Pair
-from cryptocom.exchange.structs import PrivateTrade
 from corecito_account import CorecitoAccount
 
 async def main():

--- a/corecito.py
+++ b/corecito.py
@@ -6,6 +6,7 @@ import yaml
 import sys
 import traceback
 from os.path import exists
+import cryptocom.exchange as cro
 from corecito_account import CorecitoAccount
 
 async def main():

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -83,9 +83,9 @@ class CorecitoAccount:
       self.account.order_market_buy(symbol=self.pair, quantity=quantity)
       asyncio.sleep(0.5)
 
-  async def order_market_sell(self, tx_result, quantity=0.0):
+  async def order_market_sell(self, quantity=0.0):
     if self.exchange == 'crypto.com':
-      await self.account.sell_market(self.pair, tx_result)
+      await self.account.sell_market(self.pair, quantity)
     elif self.exchange == 'binance':
       self.account.order_market_sell(symbol=self.pair, quantity=quantity)
       asyncio.sleep(0.5)

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -85,18 +85,20 @@ class CorecitoAccount:
 
   async def order_market_buy(self, tx_result, quantity=0.0):
     if self.exchange == 'crypto.com':
+      # NOTE: We use tx_result instead of quantity here because Crypto.com has a weird behaviour: it uses ETH to denominate the transaction
       await self.account.buy_market(self.pair, tx_result)
     elif self.exchange == 'binance':
       self.account.order_market_buy(symbol=self.pair, quantity=quantity)
-      asyncio.sleep(0.5)
+      await asyncio.sleep(0.5)
 
   async def order_market_sell(self, quantity=0.0):
     if self.exchange == 'crypto.com':
       await self.account.sell_market(self.pair, quantity)
     elif self.exchange == 'binance':
       self.account.order_market_sell(symbol=self.pair, quantity=quantity)
-      asyncio.sleep(0.5)
+      await asyncio.sleep(0.5)
 
+# This wrapper solves time-offset inconsistencies between local-PC time and Binance server time
 class Binance:
   def __init__(self, public_key = '', secret_key = '', sync = False):
     self.time_offset = 0

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -76,16 +76,16 @@ class CorecitoAccount:
             'core_number_currency_balance': core_number_currency_balance,
             'core_number_currency_available': core_number_currency_available})
 
-  async def order_market_buy(self, quantity=0.0):
+  async def order_market_buy(self, tx_result, quantity=0.0):
     if self.exchange == 'crypto.com':
-      await self.account.buy_market(self.pair, quantity)
+      await self.account.buy_market(self.pair, tx_result)
     elif self.exchange == 'binance':
       self.account.order_market_buy(symbol=self.pair, quantity=quantity)
       asyncio.sleep(0.5)
 
-  async def order_market_sell(self, quantity=0.0):
+  async def order_market_sell(self, tx_result, quantity=0.0):
     if self.exchange == 'crypto.com':
-      await self.account.sell_market(self.pair, quantity)
+      await self.account.sell_market(self.pair, tx_result)
     elif self.exchange == 'binance':
       self.account.order_market_sell(symbol=self.pair, quantity=quantity)
       asyncio.sleep(0.5)

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import asyncio
+import time
+import logging
+import yaml
+import sys
+from os.path import exists
+import cryptocom.exchange as cro
+from cryptocom.exchange.structs import Pair
+from cryptocom.exchange.structs import PrivateTrade
+from binance.client import Client
+
+class CorecitoAccount:
+  """Configures and runs the right code based on the selected exchange in config"""
+  def __init__(self, config=None):
+    self.exchange = config['corecito_exchange']
+    self.api_key = config['api_key']
+    self.api_secret = config['api_secret']
+    self.core_number = config['core_number']
+    self.max_decimals_buy = config['max_decimals_buy']
+    self.max_decimals_sell = config['max_decimals_sell']
+    self.min_core_number_increase_percentage = config['min_core_number_increase_percentage']
+    self.max_core_number_increase_percentage = config['max_core_number_increase_percentage']
+    self.min_core_number_decrease_percentage = config['min_core_number_decrease_percentage']
+    self.max_core_number_decrease_percentage = config['max_core_number_decrease_percentage']
+
+    if self.exchange == 'crypto.com':
+      self.account = cro.Account(api_key=self.api_key, api_secret=self.api_secret)
+      self.cro_exchange = cro.Exchange()
+      self.base_currency = config['cryptocom_base_currency']
+      self.core_number_currency = config['cryptocom_core_number_currency']
+      self.pair = eval('cro.pairs.' + config['cryptocom_trading_pair'])
+      self.cro_coin_base_currency = eval('cro.coins.' + config['cryptocom_base_currency'])
+      self.cro_coin_core_number_currency = eval('cro.coins.' + config['cryptocom_core_number_currency'])
+    elif self.exchange == 'binance':
+      self.account = Client(api_key=self.api_key, api_secret=self.api_secret)
+      self.pair = config['binance_trading_pair']
+      self.base_currency = config['binance_base_currency']
+      self.core_number_currency = config['binance_core_number_currency']
+
+    if not self.account:
+      raise Exception('Could not connect to the exchange account with provided keys!')
+
+  async def get_tickers(self):
+    # Get pair ticker info
+    if self.exchange == 'crypto.com':
+      tickers = await self.cro_exchange.get_tickers()
+      ticker = tickers[self.pair]
+      buy_price = ticker.buy_price
+      sell_price = ticker.sell_price
+    elif self.exchange == 'binance':
+      tickers = self.account.get_orderbook_tickers()
+      # Example Binance {'symbol': 'ETHBTC', 'bidPrice': '0.02706800', 'bidQty': '7.30000000', 'askPrice': '0.02707300', 'askQty': '24.00000000'} # Bid == BUY, ask == SELL
+      ticker = next((x for x in tickers if x["symbol"] == self.pair), None)
+      buy_price = float(ticker["bidPrice"])
+      sell_price = float(ticker["askPrice"])
+      await asyncio.sleep(0.5)
+
+    return({'buy_price': buy_price, 'sell_price': sell_price})
+
+  async def get_balances(self):
+    # Get account balances
+    if self.exchange == 'crypto.com':
+      balances = await self.account.get_balance()
+      base_currency_balance = balances[self.cro_coin_base_currency]
+      base_currency_available = base_currency_balance.available
+      core_number_currency_balance = balances[self.cro_coin_core_number_currency]
+      core_number_currency_available = core_number_currency_balance.available
+    elif self.exchange == 'binance':
+      print("hola")
+      base_currency_balance = self.account.get_asset_balance(asset=self.base_currency)
+      print("adios")
+      base_currency_available = float(base_currency_balance["free"])
+      core_number_currency_balance = self.account.get_asset_balance(asset=self.core_number_currency)
+      core_number_currency_available = float(core_number_currency_balance["free"])
+      await asyncio.sleep(0.5)
+
+    return({'base_currency_balance': base_currency_balance,
+            'base_currency_available': base_currency_available,
+            'core_number_currency_balance': core_number_currency_balance,
+            'core_number_currency_available': core_number_currency_available})
+
+  async def order_market_buy(self, quantity=0.0):
+    if self.exchange == 'crypto.com':
+      await self.account.buy_market(self.pair, quantity)
+    elif self.exchange == 'binance':
+      self.account.order_market_buy(symbol=self.pair, quantity=quantity)
+      asyncio.sleep(0.5)
+
+  async def order_market_sell(self, quantity=0.0):
+    if self.exchange == 'crypto.com':
+      await self.account.sell_market(self.pair, quantity)
+    elif self.exchange == 'binance':
+      self.account.order_market_sell(symbol=self.pair, quantity=quantity)
+      asyncio.sleep(0.5)

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
 import time
-import logging
-import yaml
-import sys
-from os.path import exists
 import cryptocom.exchange as cro
 from cryptocom.exchange.structs import Pair
 from cryptocom.exchange.structs import PrivateTrade


### PR DESCRIPTION
In this PR
- Binance was added but all the CRO API was disabled
- CRO pair checks removed because they don't work in the Binance library
- The buy_market method for the ETH_BTC in CRO is weird/inverted. For Binance the right amount is used

TODO: Abstract exchange values and method calls into configurable functions and make the script support both exchanges