### PR TITLE
Add ability to send errors to Telegram

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -42,5 +42,6 @@ seconds_between_iterations: 5
 
 # TELEGRAM CONFIGURATION
 telegram_notifications_on: False # must be True or False
+telegram_notify_errors: False # must be True or False
 telegram_bot_token: <bot token>
 telegram_user_id: <your user id> # In telegram app, search for '@userinfobot' and tap 'Start', it will reply with your user_id

--- a/corecito.py
+++ b/corecito.py
@@ -136,7 +136,7 @@ async def main():
         await asyncio.sleep(1)
         break
       else:
-        logger.info("Exception occurred -> '{}'. Waiting for next iteration... ({} seconds)\n\n\n".format(e, config['seconds_between_iterations']))
+        logger.logException(e, config, telegram)
         print(traceback.format_exc())
         await asyncio.sleep(config['seconds_between_iterations'])
 

--- a/corecito.py
+++ b/corecito.py
@@ -43,7 +43,7 @@ async def main():
       ###########################
       # Core Number Adjustments #
       ###########################
-      
+
       # if 'fiat', balances are calculated by multiplying buy_price
       if fiat:
         deviated_core_number = balances['base_currency_available'] * buy_price
@@ -127,7 +127,7 @@ async def main():
         # Wait given seconds until next poll
         logger.info("Waiting for next iteration... ({} seconds)\n\n\n".format(config['seconds_between_iterations']))
         await asyncio.sleep(config['seconds_between_iterations'])
-  
+
     except Exception as e:
       # Network issue(s) occurred (most probably). Jumping to next iteration
       if config['test_mode_on']:

--- a/logger.py
+++ b/logger.py
@@ -63,6 +63,12 @@ class Logger:
     log_message = f'> Price is rock-solid stable ({increase_percentage:.2f}%)'
     self.logger.info(log_message)
 
+  def logException(self, exception, config, telegram):
+    log_message = "Exception occurred -> '{}'. Waiting for next iteration... ({} seconds)\n\n\n".format(exception, config['seconds_between_iterations'])
+    self.logger.info(log_message)
+    if telegram and telegram.notifications_on and telegram.notify_errors_on:
+      telegram.send(log_message)
+
 
 def setupLogger(log_filename):
   logger = logging.getLogger('CN')

--- a/telegram.py
+++ b/telegram.py
@@ -11,6 +11,7 @@ class Telegram:
     self.bot_token = config['telegram_bot_token']
     self.bot_chatId = config['telegram_user_id']
     self.notifications_on = config['telegram_notifications_on']
+    self.notify_errors_on = config['telegram_notify_errors']
 
 
   def send(self, bot_message):


### PR DESCRIPTION
I think it's a good idea to be able to send the errors to Telegram. ☺️ 
In my case, I would like to run corecito on the cloud, and if something happens I would like to be notified without having to check the server logs.
The feature is disabled by default.
What do you think? 🤔 