### PR TITLE
ADD min and max prices to stop corecito from transacting

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -9,6 +9,9 @@ api_secret: <your Crypto.com Exchange or Binance API secret here>
 
 # CORE NUMBER SETTINGS
 core_number: 2 # EUR, ETH, etc...
+# These min and max price_stops are useful to stop corecito from selling or buying all your assets after many small deviations. Un/comment to enable/disable them.
+#min_price_stop: 0.01 # Minimum price at which it stops making transactions.
+#max_price_stop: 0.05 # Maximum price at which it stops making transactions.
 min_core_number_increase_percentage: 3
 max_core_number_increase_percentage: 10
 min_core_number_decrease_percentage: 3

--- a/corecito_account.py
+++ b/corecito_account.py
@@ -13,6 +13,8 @@ class CorecitoAccount:
     self.api_key = config['api_key']
     self.api_secret = config['api_secret']
     self.core_number = config['core_number']
+    self.min_price_stop = config['min_price_stop'] if 'min_price_stop' in config else None
+    self.max_price_stop = config['max_price_stop'] if 'max_price_stop' in config else None
     self.min_core_number_increase_percentage = config['min_core_number_increase_percentage']
     self.max_core_number_increase_percentage = config['max_core_number_increase_percentage']
     self.min_core_number_decrease_percentage = config['min_core_number_decrease_percentage']
@@ -25,6 +27,7 @@ class CorecitoAccount:
       self.base_currency = config['cryptocom_base_currency']
       self.core_number_currency = config['cryptocom_core_number_currency']
       self.pair = eval('cro.pairs.' + config['cryptocom_trading_pair'])
+      self.pair_name = self.pair.name.replace('_', '/')
       self.cro_coin_base_currency = eval('cro.coins.' + config['cryptocom_base_currency'])
       self.cro_coin_core_number_currency = eval('cro.coins.' + config['cryptocom_core_number_currency'])
       self.max_decimals_buy = config['cryptocom_max_decimals_buy']
@@ -33,6 +36,7 @@ class CorecitoAccount:
       binance = Binance(public_key = self.api_key, secret_key = self.api_secret, sync=True)
       self.account = binance.b
       self.pair = config['binance_trading_pair']
+      self.pair_name = self.pair.replace('_', '/')
       self.base_currency = config['binance_base_currency']
       self.core_number_currency = config['binance_core_number_currency']
       self.max_decimals_buy = config['binance_max_decimals_buy']

--- a/logger.py
+++ b/logger.py
@@ -11,6 +11,18 @@ class Logger:
   def info(self, msg, *args, **kwargs):
     self.logger.info(msg, *args, **kwargs)
 
+  def logPriceExploded(self, price, max_price_stop, trading_pair, telegram):
+    log_message = f'>> {trading_pair} price exploded to {price:.6f}, exceeding the max price to stop corecito {max_price_stop:.6f}'
+    self.logger.info(log_message)
+    if telegram and telegram.notifications_on:
+      telegram.send(log_message)
+
+  def logPricePlummeted(self, price, min_price_stop, trading_pair, telegram):
+    log_message = f'>> {trading_pair} price plummeted to {price:.6f}, below the min price to stop corecito {min_price_stop:.6f}'
+    self.logger.info(log_message)
+    if telegram and telegram.notifications_on:
+      telegram.send(log_message)
+
   def logCoreNumberExploded(self, increase_percentage, deviated_core_number, telegram):
     log_message = f'> Exploded {increase_percentage:.2f}%\nConsider updating CoreNumber to {deviated_core_number:.6f}'
     self.logger.info(log_message)


### PR DESCRIPTION
The goal is to not sell or buy all your assets when the price gradually deviated form your original core number too much.