### PR TITLE
Improve Dockerization using Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM python:3.8.2-slim-buster
-
-RUN apt-get update
-RUN apt-get -y install gcc
-
-RUN pip install --upgrade pip
-RUN pip install pyyaml
-RUN pip install cryptocom.exchange
-RUN pip install python-binance
+FROM microweb10/corecito_python:3.8.2
 
 ADD --chown=777 ./ /root/corecito
 


### PR DESCRIPTION
Current Dockerization has some potential problems:
- We were relying on an image called `python:3.8.2-slim-buster` and we don't know for how long it will be available.
- We were installing the latest version of `pip`, and we also don't know if that's could be a problem in the future.
- We were installing the latest version of all the libraries, and we also don't know if any of them will be not compatible with the current code.

So, since we know that the dependencies are fine now, I have uploaded a docker image called [corecito_python](https://hub.docker.com/r/microweb10/corecito_python), I have tagged the build with the tag 3.8.2, and I have made it public, so anybody can download it. ☺️ 

From now on, we will download a pre-built docker image from Docker Hub instead of building it from scratch. Which, don't forget to mention, it's a hundred times faster. 🎉 